### PR TITLE
Update echo-js-lazy-load.php to support single quoted markup

### DIFF
--- a/echo-js-lazy-load.php
+++ b/echo-js-lazy-load.php
@@ -190,6 +190,7 @@ class Echo_Js_Lazy_Load {
 	function change_img_markup( $matches ) {
 
 		$image = array_shift( $matches );
+		$image = str_replace( '\'', '"', $image );
 
 		$placeholder_image = $this->get_lazy_load_image_placeholder();
 

--- a/tests/test-main.php
+++ b/tests/test-main.php
@@ -6,6 +6,8 @@ class MainTest extends WP_UnitTestCase {
 
 	protected $content_with_image = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. <img src="http://www.example.com/image.jpg" alt="test" /> Duis faucibus quis diam in molestie. Donec elementum risus sodales tristique malesuada, nisl eros accumsan odio';
 
+	protected $content_with_image_single_quotes = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. <img src=\'http://www.example.com/image.jpg\' alt=\'test\' /> Duis faucibus quis diam in molestie. Donec elementum risus sodales tristique malesuada, nisl eros accumsan odio';
+
 	protected $content_with_image_srcset = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. <img src="http://www.example.com/image.jpg" srcset="http://www.example.com/image.jpg 1w" alt="test" /> Duis faucibus quis diam in molestie. Donec elementum risus sodales tristique malesuada, nisl eros accumsan odio';
 
 	protected $content_with_image_atr = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. <img src="http://www.example.com/image.jpg" data-echo="http://www.example.com/image.jpg" alt="test" /> Duis faucibus quis diam in molestie. Donec elementum risus sodales tristique malesuada, nisl eros accumsan odio';
@@ -28,6 +30,7 @@ class MainTest extends WP_UnitTestCase {
 		add_filter( 'echo_js_lazy_load_enabled', '__return_true' );
 
 		$this->assertContains( 'data-echo', $this->plugin_class->filter_content( $this->content_with_image ) );
+		$this->assertContains( 'data-echo', $this->plugin_class->filter_content( $this->content_with_image_single_quotes ) );
 		$this->assertContains( 'data-echo', $this->plugin_class->filter_content( $this->content_with_image_atr ) );
 		$this->assertContains( 'data-echo', $this->plugin_class->filter_content( $this->content_with_image_srcset ) );
 		$this->assertNotContains( 'data-echo', $this->plugin_class->filter_content( $this->content_with_image_no_src ) );
@@ -37,6 +40,7 @@ class MainTest extends WP_UnitTestCase {
 	}
 
 
+
 	function testFilterContentPlaceholder() {
 
 		add_filter( 'echo_js_lazy_load_enabled', '__return_true' );
@@ -44,6 +48,7 @@ class MainTest extends WP_UnitTestCase {
 		$placeholder_image = $this->plugin_class->get_lazy_load_image_placeholder();
 
 		$this->assertContains( $placeholder_image, $this->plugin_class->filter_content( $this->content_with_image ) );
+		$this->assertContains( $placeholder_image, $this->plugin_class->filter_content( $this->content_with_image_single_quotes ) );
 		$this->assertContains( $placeholder_image, $this->plugin_class->filter_content( $this->content_with_image_srcset ) );
 		$this->assertNotContains( $placeholder_image, $this->plugin_class->filter_content( $this->content_with_image_no_src ) );
 		$this->assertNotContains( $placeholder_image, $this->plugin_class->filter_content( $this->content_with_image_atr ) );
@@ -57,6 +62,7 @@ class MainTest extends WP_UnitTestCase {
 
 		$this->assertNotContains( 'data-echo', $this->plugin_class->filter_content( $this->content_without_image ) );
 		$this->assertNotContains( 'data-echo', $this->plugin_class->filter_content( $this->content_with_image ) );
+		$this->assertNotContains( 'data-echo', $this->plugin_class->filter_content( $this->content_with_image_single_quotes ) );
 		$this->assertNotContains( 'data-echo', $this->plugin_class->filter_content( $this->content_with_image_no_src ) );
 		$this->assertNotContains( 'data-echo', $this->plugin_class->filter_content( $this->content_with_image_srcset ) );
 		$this->assertNotContains( 'data-echo-srcset', $this->plugin_class->filter_content( $this->content_with_image_srcset ) );
@@ -76,6 +82,7 @@ class MainTest extends WP_UnitTestCase {
 
 		$this->assertNotContains( 'data-echo-srcset', $this->plugin_class->filter_content( $this->content_without_image ) );
 		$this->assertNotContains( 'data-echo-srcset', $this->plugin_class->filter_content( $this->content_with_image ) );
+		$this->assertNotContains( 'data-echo-srcset', $this->plugin_class->filter_content( $this->content_with_image_single_quotes ) );
 		$this->assertNotContains( 'data-echo-srcset', $this->plugin_class->filter_content( $this->content_with_image_no_src ) );
 		$this->assertNotContains( 'data-echo-srcset', $this->plugin_class->filter_content( $this->content_with_image_atr ) );
 


### PR DESCRIPTION
Fix to support single quoted markup. For example, get_avatar() function returns the attributes in single quotes, so class='...' needs to be to transformed  to class="..." before running the lazy load functionality.
